### PR TITLE
Adapt state regex to work with new TLC versions

### DIFF
--- a/render_timeline.py
+++ b/render_timeline.py
@@ -112,7 +112,7 @@ def render_msg_steps(msg_steps, clients):
 def max_step(msg_steps):
     return max([m.recvAt for m in msg_steps])
 
-state_re = re.compile(r'State \d+:.*?\n(.+?)\n\n', re.DOTALL)
+state_re = re.compile(r'\d+: <.*?>\n(.+?)\n\n', re.DOTALL)
 
 def parse_states(tlc_output):
     """

--- a/test_render_timeline.py
+++ b/test_render_timeline.py
@@ -1,6 +1,8 @@
+import pytest
+
 from render_timeline import parse_states, extract_msg_steps, extract_clients
 
-tlc_output = r'''
+tlc_output_old_format = r'''
 State 5: <client line 65, col 20 to line 69, col 40 of module two_client_reliable_channel>
 /\ C = [ ClientInboxes |->
       [ client1 |->
@@ -74,7 +76,85 @@ State 6: <client line 65, col 20 to line 69, col 40 of module two_client_reliabl
 
 '''
 
-def test_parse_states():
+tlc_output_new_format = r'''
+5: <client line 65, col 20 to line 69, col 40 of module two_client_reliable_channel>
+/\ C = [ ClientInboxes |->
+      [ client1 |->
+            << [ rawMsg |->
+                     [ receiver |-> "client1",
+                       sender |-> "client2",
+                       msgLabel |-> "1",
+                       senderState |-> 1,
+                       receiverState |-> "",
+                       sendAt |-> 2,
+                       payload |-> 1,
+                       recvAt |-> -1 ] ],
+               [ rawMsg |->
+                     [ receiver |-> "client1",
+                       sender |-> "client2",
+                       msgLabel |-> "1",
+                       senderState |-> 2,
+                       receiverState |-> "",
+                       sendAt |-> 3,
+                       payload |-> 1,
+                       recvAt |-> -1 ] ] >>,
+        client2 |-> <<>> ],
+  LogicalTime |-> 4,
+  MsgSteps |->
+      { [ receiver |-> "client2",
+          sender |-> "client1",
+          msgLabel |-> "1",
+          senderState |-> 1,
+          receiverState |-> 3,
+          sendAt |-> 1,
+          payload |-> "",
+          recvAt |-> 4 ] },
+  NextMsgId |-> 3 ]
+/\ GlobalCount = [client1 |-> 1, client2 |-> 3]
+/\ MsgsSent = [client1 |-> 1, client2 |-> 2]
+
+6: <client line 65, col 20 to line 69, col 40 of module two_client_reliable_channel>
+/\ C = [ ClientInboxes |->
+      [ client1 |->
+            << [ rawMsg |->
+                     [ receiver |-> "client1",
+                       sender |-> "client2",
+                       msgLabel |-> "1",
+                       senderState |-> 2,
+                       receiverState |-> "",
+                       sendAt |-> 3,
+                       payload |-> 1,
+                       recvAt |-> -1 ] ] >>,
+        client2 |-> <<>> ],
+  LogicalTime |-> 5,
+  MsgSteps |->
+      { [ receiver |-> "client1",
+          sender |-> "client2",
+          msgLabel |-> "1",
+          senderState |-> 1,
+          receiverState |-> 2,
+          sendAt |-> 2,
+          payload |-> "",
+          recvAt |-> 5 ],
+        [ receiver |-> "client2",
+          sender |-> "client1",
+          msgLabel |-> "1",
+          senderState |-> 1,
+          receiverState |-> 3,
+          sendAt |-> 1,
+          payload |-> "",
+          recvAt |-> 4 ] },
+  NextMsgId |-> 3 ]
+/\ GlobalCount = [client1 |-> 2, client2 |-> 3]
+/\ MsgsSent = [client1 |-> 1, client2 |-> 2]
+
+'''
+
+
+@pytest.mark.parametrize(
+    "tlc_output", [tlc_output_old_format, tlc_output_new_format]
+)
+def test_parse_states(tlc_output):
     states = parse_states(tlc_output)
     assert len(states) == 2
 
@@ -87,7 +167,11 @@ def test_parse_states():
     clients = extract_clients(final_state)
     assert clients == ['client1', 'client2']
 
-def test_parser_can_find_channels_under_any_name():
+
+@pytest.mark.parametrize(
+    "tlc_output", [tlc_output_old_format, tlc_output_new_format]
+)
+def test_parser_can_find_channels_under_any_name(tlc_output):
     tlc_output_adjusted = tlc_output.replace(r'/\ C =', r'/\ OtherName =')
 
     steps = extract_msg_steps(parse_states(tlc_output_adjusted)[-1])


### PR DESCRIPTION
In recent versions the "State " in the trace output is missing.